### PR TITLE
fix(renovate): add limitations to regulate CIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
         ":automergeBranchPush",
         ":semanticCommits",
         ":rebaseStalePrs",
+        ":prConcurrentLimit4",
+        ":prHourlyLimit2",
         ":timezone(Europe/Paris)"
       ]
     }


### PR DESCRIPTION
## Objective

Following a discussion on Slack, we are having trouble with CircleCI being flooded with Renovate jobs from multiple projects, hijacking CircleCI bandwidth. This is slowing down the build time for all other projects.

This PR tends to add some regulation to smooth out the Renovate PRs creations by adding two parameters to the shared config:

#### [`:prHourlyLimit2`](https://docs.renovatebot.com/configuration-options/#prhourlylimit)

Renovate will create at most 2 PRs per hour. This does not limit the total number of PRs open concurrently.

This avoids creating all Renovate PRs at the same time and regulate them over time.

#### [`:prConcurrentLimit4`](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit)

Renovate will limit the number of opened PRs to 4 at the same time.

This would help reduce the number of jobs running on CircleCI by avoiding restarting the tests on all other opened PRs.

## Misc

With these regulations, it allows a maximum of ~100 Renovate PRs per weekend per project. This should be enough for most projects.

In case Renovate PRs fails, there will be a maximum of 4 opened PRs at the same time.

Let me know what you think of these limits! Definitely open to tweak them!