### PR TITLE
fix(renovate): fixing non existing option

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         ":automergeBranchPush",
         ":semanticCommits",
         ":rebaseStalePrs",
-        ":prConcurrentLimit4",
+        ":prConcurrentLimit10",
         ":prHourlyLimit2",
         ":timezone(Europe/Paris)"
       ]


### PR DESCRIPTION
`:prConcurrentLimit4` doesn't exists, it has to be pre-defined first. Let's try with `10` as it's still an improvement.