### PR TITLE
fix(renovate): do not update PRs when not scheduled

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         ":prConcurrentLimit10",
         ":prHourlyLimit2",
         ":timezone(Europe/Paris)"
-      ]
+      ],
+      "updateNotScheduled": false
     }
   },
   "scripts": {


### PR DESCRIPTION
This PR makes renovate not update stale PRs during week days.
ref: https://github.com/apollographql/renovate-config-apollo-open-source/pull/2