### PR TITLE
docs: improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # renovate-config-algolia
 
-This repository holds a [shareable configuration](https://renovateapp.com/docs/configuration-reference/config-presets), much like [algolia/eslint-config-algolia](https://github.com/algolia/eslint-config-algolia/).
+This repository holds a [Renovate shareable configuration](https://renovateapp.com/docs/configuration-reference/config-presets), much like [algolia/eslint-config-algolia](https://github.com/algolia/eslint-config-algolia/).
 
-[Renovate](https://renovateapp.com/) keeps npm dependencies up-to-date. The right
-way, the right features and right time.
+[Renovate](https://renovateapp.com/) keeps npm dependencies up-to-date.
+The right way, the right features and right time.
 
 ## How to use it
 
-### 1. Create a renovate.json file:
+### 1. Create a `renovate.json` file:
 
-If you have a **JavaScript application** (dashboard, static website generator), put in `renovate.json`:
+If you have a **JavaScript application** (dashboard, static website generator), put this in your `renovate.json`:
 
 ```json
 {
@@ -25,20 +25,23 @@ If you have a **JavaScript library**:
 }
 ```
 
-The only difference between the two configuration is that, an application, will have `devDependencies` AND `dependencies` pinned. While a JavaScript library will only have `devDependencies` pinned.
+The only difference between the two configurations is that an application will have its `devDependencies` _and_ `dependencies` pinned.
+While a JavaScript library will only have its `devDependencies` pinned.
+Read the [Renovate docs, dependency pinning](https://renovatebot.com/docs/dependency-pinning/) to learn more.
 
-There's no need to install `renovate-config-algolia`, it's automatically picked up by renovate for now.
+You do not need to install `renovate-config-algolia`, as it's automatically picked up by Renovate.
 
-[Read more](https://renovatebot.com/docs/dependency-pinning/) about dependencies pinning.
-
-### 2. Activate renovate
+### 2. Activate Renovate
 
 Go to <https://github.com/apps/renovate>, ask a GitHub admin of the organisation if you need help on how to do this step.
 
 ## What's inside the configuration?
 
-This configuration is made to automerge any minor and patch updates to any dependencies in your repository. It will directly push to the GitHub default branch of your project.
+The Renovate configuration automerges any minor and patch updates to any dependencies in your repository.
+It will directly push to the GitHub default branch of your project.
 
 It runs every weekend, Paris time.
 
-We choosed to have a configuration that directly push to GitHub to avoid any notification noise inside GitHub by having a lot of Pull Requests to merge manually. If the update passes your test suite, then it's merged directly. If tests are not passing or if there's a major upgrade then a pull request will be opened.
+We chose to have a configuration that directly pushes to GitHub to avoid any notification noise inside GitHub by having a lot of Pull Requests to merge manually.
+If the update passes your test suite, then it's merged directly.
+If tests are not passing or if there's a major upgrade then a pull request will be opened.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This repository holds a [Renovate shareable configuration](https://renovateapp.com/docs/configuration-reference/config-presets), much like [algolia/eslint-config-algolia](https://github.com/algolia/eslint-config-algolia/).
 
-[Renovate](https://renovateapp.com/) keeps npm dependencies up-to-date.
-The right way, the right features and right time.
+[Renovate](https://renovateapp.com/) keeps npm dependencies up-to-date the right way, the right features and right time.
 
 ## How to use it
 


### PR DESCRIPTION
## Changes:

- Capitalize proper noun Renovate
- Improve and simplify some sentences
- Be explicit where a link will take you
- Use italics instead of capitalization for emphasis of the word and
- Use one sentence per line pattern (but feel free to ignore this in future), I just find this easier to edit later on 😉 

## Context:

I hope you'll like the changes to the README, it should be easier to understand now, and be easier to edit in future.